### PR TITLE
Issue #41: CompositeSettingsDictionary.AsString() failes when the dic…

### DIFF
--- a/Fig.Core/CompositeSettingsDictionary.cs
+++ b/Fig.Core/CompositeSettingsDictionary.cs
@@ -54,8 +54,8 @@ namespace Fig
         public string AsString()
         {
             var maxWidths = new int[2];
-            maxWidths[0] = _dictionaries.SelectMany(d => d.Keys).Max(k => k.Length) + 1;
-            maxWidths[1] = _dictionaries.SelectMany(d => d.Values).Max(k => k.Length);
+            maxWidths[0] = _dictionaries.SelectMany(d => d.Keys).MaxOrDefault(k => k.Length) + 1;
+            maxWidths[1] = _dictionaries.SelectMany(d => d.Values).MaxOrDefault(k => k.Length);
             var minWidth = 22;
             var colWidths = new int[2]
             {
@@ -83,7 +83,11 @@ namespace Fig
                 }
             }
 
-            sb.AppendLine("-".PadRight(colWidths.Sum(w => w) + 7, '-'));
+            // Only append a line, if there was data in the dictionary.
+            if (_dictionaries.Count > 0)
+            {
+                sb.AppendLine("-".PadRight(colWidths.Sum(w => w) + 7, '-'));
+            }
 
             return sb.ToString();
         }

--- a/Fig.Core/EnumerableExtensions.cs
+++ b/Fig.Core/EnumerableExtensions.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Fig
+{
+    public static class EnumerableExtensions
+    {
+        public static int MaxOrDefault<T>(this IEnumerable<T> enumeration, Func<T, int> selector)
+        {
+            return enumeration.Any() ? enumeration.Max(selector) : default(int);
+        }
+    }
+}

--- a/Fig.Tests/DictionaryTests.cs
+++ b/Fig.Tests/DictionaryTests.cs
@@ -97,14 +97,22 @@ namespace Fig.Test
             var toString = settings.ToString();
             
             Console.WriteLine(toString);
-            
-            var expected =   "-------------------- Layer 0 ----------------------\n"
-                           + "| a                      | b                      |\n"
-                           + "-------------------- Layer 1 ----------------------\n"
-                           + "| c:prod                 | d                      |\n"
-                           + "---------------------------------------------------\n";
-            
+
+            var expected =   "-------------------- Layer 0 ----------------------" + Environment.NewLine
+                           + "| a                      | b                      |" + Environment.NewLine
+                           + "-------------------- Layer 1 ----------------------" + Environment.NewLine
+                           + "| c:prod                 | d                      |" + Environment.NewLine
+                           + "---------------------------------------------------" + Environment.NewLine;
+
             Assert.AreEqual(expected, toString);
+        }
+
+        [Test]
+        public void EmptyCompositeDictionaryAsStringReturnsCorrectResult()
+        {
+            var settingsString = new CompositeSettingsDictionary()
+                .AsString();
+            Assert.AreEqual(string.Empty, settingsString);
         }
 
         [Test]


### PR DESCRIPTION
Hi, I fixed this issue and also fixed the test to use the Environment variables, because the test would fail if run on a mac or windows machine. @rofr 